### PR TITLE
handle invalidParameters error response

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@
 /pkg/
 /spec/reports/
 /tmp/
+/.ruby-version
+/.ruby-gemset
+/.idea

--- a/lib/bankid/poll.rb
+++ b/lib/bankid/poll.rb
@@ -2,14 +2,20 @@
 
 module Bankid
   class Poll
-    ATTRS = %i[order_ref status hint_code completion_data].freeze
+    ATTRS = %i[order_ref status hint_code completion_data error_code details].freeze
     attr_accessor(*ATTRS)
 
-    def initialize(order_ref: nil, status: nil, hint_code: nil, completion_data: {})
+    def initialize(order_ref: nil, status: nil, hint_code: nil, completion_data: {}, error_code: nil, details: nil)
       @order_ref = order_ref
       @status = status
+      @status = status
+      @error_code = error_code
+      @details = details
       @hint_code = hint_code
       @completion_data = completion_data
+      if @error_code.to_s.length > 0 && @status.to_s.length == 0
+        @status = 'failed'
+      end
     end
 
     def completed?


### PR DESCRIPTION
In case when order_ref is non existing bankid api returns error message with additional attributes error_code && details like
{"errorCode":"invalidParameters","details":"No such order"}
this should fix this problem.

