### PR TITLE
gemspec: Drop unused executables directive

### DIFF
--- a/bankid.gemspec
+++ b/bankid.gemspec
@@ -27,8 +27,6 @@ Gem::Specification.new do |spec|
       (f == __FILE__) || f.match(%r{\A(?:(?:test|spec|features)/|\.(?:git|travis|circleci)|appveyor)})
     end
   end
-  spec.bindir        = "exe"
-  spec.executables   = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
   # Uncomment to register a new dependency of your gem


### PR DESCRIPTION
This PR drops unused parts of the gemspec file.